### PR TITLE
Implement success toast for deployment save

### DIFF
--- a/deployments-comparison.html
+++ b/deployments-comparison.html
@@ -90,8 +90,10 @@
 		</div>
 	  </div>
 
-	</div>
+        </div>
   </div>
+
+  <div id="toastContainer" class="toast-container position-fixed top-0 end-0 p-3"></div>
 
   <!-- Bootstrap JS Bundle -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
@@ -104,6 +106,20 @@
     const sessionLabel  = document.getElementById('sessionLabel');
     const generateBtn = document.getElementById('generateBtn');
     const compareGlobal = document.getElementById('compareGlobal');
+    const toastContainer = document.getElementById('toastContainer');
+
+    function showSuccessToast(name) {
+      const el = document.createElement('div');
+      el.className = 'toast align-items-center text-bg-success border-0';
+      el.role = 'alert';
+      el.setAttribute('aria-live', 'assertive');
+      el.setAttribute('aria-atomic', 'true');
+      el.innerHTML = `<div class="d-flex"><div class="toast-body">Deployment "${name}" saved successfully.</div></div>`;
+      toastContainer.appendChild(el);
+      const toast = new bootstrap.Toast(el, { delay: 1000 });
+      toast.show();
+      el.addEventListener('hidden.bs.toast', () => el.remove());
+    }
 
     function updateSessionLabel() {
       sessionLabel.textContent = sessionSwitch.checked
@@ -374,6 +390,7 @@ function handleCheckboxChange(e) {
       collapse.appendChild(body);
       item.appendChild(collapse);
       containerEl.appendChild(item);
+      showSuccessToast(name);
     }
 
     generateBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- show a success toast when creating a deployment card
- add toast container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aed444b308324b03f5de90835f737